### PR TITLE
Change the maximum arbitrary social security witholding.

### DIFF
--- a/src/core/tests/arbitraries.ts
+++ b/src/core/tests/arbitraries.ts
@@ -60,6 +60,7 @@ const investmentResult = posNegCurrency(100000)
 const expense: Arbitrary<number> = posCurrency(10000)
 const interest: Arbitrary<number> = posCurrency(10000)
 const payment: Arbitrary<number> = fc.nat({ max: 100000 })
+const ssWitholding: Arbitrary<number> = fc.nat({ max: 10000 })
 
 const payerName: Arbitrary<string> = maxWords(3)
 
@@ -106,7 +107,7 @@ const w2: Arbitrary<types.IncomeW2> = wages.chain((income) =>
       fc.nat({ max: 2 * income }),
       fc.nat({ max: income }),
       fc.nat({ max: income }),
-      fc.nat({ max: income }),
+      ssWitholding,
       fc.nat({ max: income }),
       employer,
       w2Box12Info(income),


### PR DESCRIPTION
The previous code used a very large number (10,000,000) as the
maximum possible amount of social security tax withheld, however
this is not possible as in real life the amount should be less
than $8500. Because of this large mismatch the test was being
skipped 100% of the time.

This fix creates a new arbitrary maximum of 10,000 which is much
closer to the range of real values and now allows the test to run

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ustaxes/ustaxes/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

**What kind of change does this PR introduce?** (delete not applicable)
- Bugfix
- Feature
- Docs
- Code style update
- Refactor
- Build-related changes
- Other, please describe:

<!-- 
If this PR resolves a specific issue include "Fixes #xxx" in the PR description so the issue is linked and automatically closed on merge.

Please sign all your commits. See https://github.com/ustaxes/UsTaxes/blob/master/docs/CONTRIBUTING.md#pull-request-guidelines for information on setting this up.

-->
